### PR TITLE
chore: normalise rids

### DIFF
--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -66,14 +66,14 @@
       </Content>
       <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64-musl\libpact_ffi.so">
         <Link>libpact_ffi.so</Link>
-        <PackagePath>runtimes/linux-x64-musl/native</PackagePath>
+        <PackagePath>runtimes/linux-musl-x64/native</PackagePath>
         <Pack>true</Pack>
         <CopyToOutputDirectory Condition="'$(IsLinuxMuslX64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
         <Visible>false</Visible>
       </Content>
       <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\aarch64-musl\libpact_ffi.so">
         <Link>libpact_ffi.so</Link>
-        <PackagePath>runtimes/linux-arm64-musl/native</PackagePath>
+        <PackagePath>runtimes/linux-musl-arm64/native</PackagePath>
         <Pack>true</Pack>
         <CopyToOutputDirectory Condition="'$(IsLinuxMuslArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
         <Visible>false</Visible>


### PR DESCRIPTION
NETSDK1206: Found version-specific or distribution-specific runtime identifier(s): linux-arm64-musl, linux-x64-musl. Affected libraries: PactNet. In .NET 8.0 and higher, assets for version-specific and distribution-specific runtime identifiers will not be found by default. See https://aka.ms/dotnet/rid-usage for details.